### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/xcellardoor/up_down_tester.png?label=ready&title=Ready)](https://waffle.io/xcellardoor/up_down_tester?utm_source=badge)
 # Up-Down Tester
 
 Build Status Be Like - [![Build Status](https://travis-ci.org/xcellardoor/up_down_tester.svg?branch=master)](https://travis-ci.org/xcellardoor/up_down_tester)


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/xcellardoor/up_down_tester

This was requested by a real person (user xcellardoor) on waffle.io, we're not trying to spam you.